### PR TITLE
Fixes #30 Delete multiple trackers `announce-list` from downloads

### DIFF
--- a/api/src/controllers/torrent.js
+++ b/api/src/controllers/torrent.js
@@ -251,6 +251,7 @@ export const downloadTorrent = async (req, res, next) => {
     const parsed = bencode.decode(Buffer.from(binary, "base64"));
 
     parsed.announce = `${process.env.SQ_BASE_URL}/sq/${user.uid}/announce`;
+    delete parsed["announce-list"];
     parsed.info.private = 1;
 
     res.setHeader("Content-Type", "application/x-bittorrent");


### PR DESCRIPTION
Fixes #30 
Multiple trackers are still preserved on upload, but stripped out on the download.