### PR TITLE
Update source value in torrent metadata

### DIFF
--- a/api/src/controllers/torrent.js
+++ b/api/src/controllers/torrent.js
@@ -68,6 +68,7 @@ export const uploadTorrent = async (req, res, next) => {
       const user = await User.findOne({ _id: req.userId }).lean();
 
       parsed.info.private = 1;
+      parsed.info.source = `${process.env.SQ_BASE_URL}`;
       parsed.announce = `${process.env.SQ_BASE_URL}/sq/${user.uid}/announce`;
       delete parsed["announce-list"];
 
@@ -254,6 +255,7 @@ export const downloadTorrent = async (req, res, next) => {
     parsed.announce = `${process.env.SQ_BASE_URL}/sq/${user.uid}/announce`;
     delete parsed["announce-list"];
     parsed.info.private = 1;
+    parsed.info.source = `${process.env.SQ_BASE_URL}`;
 
     const fileName = `${parsed.info.name.toString()} - ${
       process.env.SQ_SITE_NAME


### PR DESCRIPTION
I noticed that SQLTracker doesn't modify the source value in the torrent file's metadata. This causes the downloader to incorrectly identify it as identical to another torrent file. 