### PR TITLE
fix cover image going out of frame on mobile devices

### DIFF
--- a/client/pages/torrent/[infoHash].js
+++ b/client/pages/torrent/[infoHash].js
@@ -683,8 +683,8 @@ const Torrent = ({ token, torrent = {}, userId, userRole, uid, userStats }) => {
             alt={`Cover image for “${torrent.name}”`}
             width="auto"
             height="auto"
-            maxWidth="500px"
-            maxHeight="500px"
+            maxWidth="400px"
+            maxHeight="400px"
           />
         </Infobox>
       )}


### PR DESCRIPTION
Before:
![1-photo_2024-02-23_12-31-35](https://github.com/tdjsnelling/sqtracker/assets/17676089/cb4ef1d0-09f2-4d7e-8160-c589e4c237bc)
After:
![2-photo_2024-02-23_12-32-50](https://github.com/tdjsnelling/sqtracker/assets/17676089/712430c1-cea7-4710-aa54-af96c534624f)
